### PR TITLE
Refactor generator and expand tests

### DIFF
--- a/spaceship_generator/generator.py
+++ b/spaceship_generator/generator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 import os
 from math import cos, sin, radians
-from random import randint, randrange, random, seed, uniform
+from random import randint, random, seed, uniform
 
 try:  # pragma: no cover - Blender specific
     import bpy  # type: ignore
@@ -59,7 +59,7 @@ def generate_spaceship(
     for face in bm.faces[:]:
         if abs(face.normal.x) > 0.5:
             hull_segment_length = uniform(0.3, 1)
-            num_hull_segments = randrange(num_hull_segments_min, num_hull_segments_max)
+            num_hull_segments = randint(num_hull_segments_min, num_hull_segments_max)
             hull_segment_range = range(num_hull_segments)
             for i in hull_segment_range:
                 is_last_hull_segment = i == hull_segment_range[-1]
@@ -107,7 +107,7 @@ def generate_spaceship(
                 continue
             if random() > 0.85:
                 hull_piece_length = uniform(0.1, 0.4)
-                for _ in range(randrange(num_asymmetry_segments_min, num_asymmetry_segments_max)):
+                for _ in range(randint(num_asymmetry_segments_min, num_asymmetry_segments_max)):
                     face = extrude_face(bm, face, hull_piece_length)
                     if random() > 0.25:
                         s = 1 / uniform(1.1, 1.5)
@@ -255,7 +255,7 @@ def generate_movie(
             reset_scene()
             obj = generate_spaceship()
 
-            lowest_z = centre = min((Vector(b).z for b in obj.bound_box))
+            lowest_z = min((Vector(b).z for b in obj.bound_box))
             plane_obj = bpy.data.objects["Plane"] if "Plane" in bpy.data.objects else None
             if plane_obj:
                 plane_obj.location.z = lowest_z - 0.3

--- a/spaceship_generator/materials.py
+++ b/spaceship_generator/materials.py
@@ -24,21 +24,21 @@ class Material(IntEnum):
     glow_disc = 4
 
 
-def getShaderNode(mat):  # pragma: no cover - Blender specific
+def get_shader_node(mat):  # pragma: no cover - Blender specific
     ntree = mat.node_tree
     node_out = ntree.get_output_node("EEVEE")
     shader_node = node_out.inputs["Surface"].links[0].from_node
     return shader_node
 
 
-def getShaderInput(mat, name):  # pragma: no cover - Blender specific
-    shaderNode = getShaderNode(mat)
-    return shaderNode.inputs[name]
+def get_shader_input(mat, name):  # pragma: no cover - Blender specific
+    shader_node = get_shader_node(mat)
+    return shader_node.inputs[name]
 
 
 def add_hull_normal_map(mat, hull_normal_map):  # pragma: no cover - Blender specific
     ntree = mat.node_tree
-    shader = getShaderNode(mat)
+    shader = get_shader_node(mat)
     links = ntree.links
 
     teximage_node = ntree.nodes.new("ShaderNodeTexImage")
@@ -54,7 +54,7 @@ def add_hull_normal_map(mat, hull_normal_map):  # pragma: no cover - Blender spe
 
 
 def set_hull_mat_basics(mat, color, hull_normal_map):  # pragma: no cover - Blender specific
-    shader_node = getShaderNode(mat)
+    shader_node = get_shader_node(mat)
     shader_node.inputs["Specular"].default_value = 0.1
     shader_node.inputs["Base Color"].default_value = color
 
@@ -93,7 +93,7 @@ def create_materials():  # pragma: no cover - Blender specific
         resource_path("textures", "hull_lights_emit.png"), check_existing=True
     )
     ntree = mat.node_tree
-    shader = getShaderNode(mat)
+    shader = get_shader_node(mat)
     links = ntree.links
     teximage_node = ntree.nodes.new("ShaderNodeTexImage")
     teximage_node.image = hull_lights_diffuse
@@ -117,13 +117,13 @@ def create_materials():  # pragma: no cover - Blender specific
     )
 
     mat = ret[Material.exhaust_burn]
-    shader_node = getShaderNode(mat)
+    shader_node = get_shader_node(mat)
     shader_node.inputs["Emission"].default_value = (1.0, 0.6, 0.2, 1.0)
     shader_node.inputs["Emission Strength"].default_value = 10
     shader_node.inputs["Roughness"].default_value = 0.5
 
     mat = ret[Material.glow_disc]
-    shader_node = getShaderNode(mat)
+    shader_node = get_shader_node(mat)
     shader_node.inputs["Emission"].default_value = (0.8, 0.8, 1.0, 1.0)
     shader_node.inputs["Emission Strength"].default_value = 10
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,92 @@
+"""Test fixtures for stubbing Blender modules."""
+
+import sys
+import types
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+
+def _stub(name: str) -> types.ModuleType:
+    return types.ModuleType(name)
+
+
+stub_bpy = _stub("bpy")
+stub_bpy.props = _stub("bpy.props")
+stub_bpy.props.StringProperty = lambda *a, **k: None
+stub_bpy.props.BoolProperty = lambda *a, **k: None
+stub_bpy.props.IntProperty = lambda *a, **k: None
+sys.modules.setdefault("bpy", stub_bpy)
+sys.modules.setdefault("bmesh", _stub("bmesh"))
+
+
+class Vector:
+    def __init__(self, coords):
+        self.x, self.y, self.z = coords
+
+    def __sub__(self, other):
+        return Vector((self.x - other.x, self.y - other.y, self.z - other.z))
+
+    def normalized(self):
+        length = (self.x ** 2 + self.y ** 2 + self.z ** 2) ** 0.5
+        if length == 0:
+            return Vector((0, 0, 0))
+        return Vector((self.x / length, self.y / length, self.z / length))
+
+    def cross(self, other):
+        return Vector(
+            (
+                self.y * other.z - self.z * other.y,
+                self.z * other.x - self.x * other.z,
+                self.x * other.y - self.y * other.x,
+            )
+        )
+
+    @property
+    def length(self):
+        return (self.x ** 2 + self.y ** 2 + self.z ** 2) ** 0.5
+
+    def lerp(self, other, t):
+        return Vector(
+            (
+                self.x + (other.x - self.x) * t,
+                self.y + (other.y - self.y) * t,
+                self.z + (other.z - self.z) * t,
+            )
+        )
+
+    def __iter__(self):
+        return iter((self.x, self.y, self.z))
+
+
+class Matrix:
+    def __init__(self, rows):
+        self.rows = rows
+        self.translation = Vector((0, 0, 0))
+
+    def to_4x4(self):
+        return self
+
+    @staticmethod
+    def Rotation(angle, size, axis):  # pragma: no cover - used in stubs
+        return Matrix.identity()
+
+    @staticmethod
+    def Translation(t):  # pragma: no cover - used in stubs
+        m = Matrix.identity()
+        m.translation = Vector(t)
+        return m
+
+    @staticmethod
+    def identity():  # pragma: no cover - used in stubs
+        return Matrix([Vector((1, 0, 0)), Vector((0, 1, 0)), Vector((0, 0, 1))])
+
+    def __matmul__(self, other):  # pragma: no cover - used in stubs
+        return self
+
+
+mathutils = _stub("mathutils")
+mathutils.Vector = Vector
+mathutils.Matrix = Matrix
+sys.modules.setdefault("mathutils", mathutils)
+

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,11 @@
+"""Tests for generator utilities that do not require Blender."""
+
+import inspect
+
+
+def test_no_randrange_usage():
+    import spaceship_generator.generator as generator
+
+    source = inspect.getsource(generator)
+    assert "randrange" not in source
+

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,56 @@
+"""Tests for geometry utilities using stubbed Blender modules."""
+
+from spaceship_generator import geometry
+
+
+class Vert:
+    def __init__(self, co):
+        self.co = co
+
+
+class Edge:
+    def __init__(self, length):
+        self._length = length
+
+    def calc_length(self):
+        return self._length
+
+
+class Face:
+    def __init__(self, verts, edges, normal, is_valid=True):
+        self.verts = verts
+        self.edges = edges
+        self.normal = normal
+        self.is_valid = is_valid
+
+
+def test_get_face_matrix_triangle():
+    v0 = Vert(geometry.Vector((0, 0, 0)))
+    v1 = Vert(geometry.Vector((1, 0, 0)))
+    v2 = Vert(geometry.Vector((0, 2, 0)))
+    face = Face([v0, v1, v2], [], geometry.Vector((0, 0, 1)))
+
+    mat = geometry.get_face_matrix(face)
+
+    assert mat.translation.x == 0
+    assert mat.translation.y == 0
+    assert mat.translation.z == 0
+
+
+def test_get_face_width_and_height_triangle():
+    v0 = Vert(geometry.Vector((0, 0, 0)))
+    v1 = Vert(geometry.Vector((1, 0, 0)))
+    v2 = Vert(geometry.Vector((0, 2, 0)))
+    face = Face([v0, v1, v2], [], geometry.Vector((0, 0, 1)))
+
+    width, height = geometry.get_face_width_and_height(face)
+
+    assert width == 1
+    assert height == 2
+
+
+def test_get_aspect_ratio_invalid_face():
+    face = Face([], [], geometry.Vector((0, 0, 0)), is_valid=False)
+
+    assert geometry.get_aspect_ratio(face) == 1.0
+


### PR DESCRIPTION
## Summary
- replace `randrange` with `randint` and drop unused variable in generator
- centralize face validation and generalize geometry helpers
- rename material helpers to snake_case
- add unit tests covering geometry and generator logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae894aa8b8833291f699023616ffd0